### PR TITLE
Added more flexiable way to handle preexistent epics environment variables 

### DIFF
--- a/e3TemplateGenerator/.e3_common_functions
+++ b/e3TemplateGenerator/.e3_common_functions
@@ -601,6 +601,24 @@ EOF
 
 }
 
+
+function add_RELEASE_variables
+{
+    cat > RELEASE <<"EOF"
+#
+EPICS_BASE=$(EPICS_BASE)
+
+E3_REQUIRE_NAME:=$(E3_REQUIRE_NAME)
+E3_REQUIRE_VERSION:=$(E3_REQUIRE_VERSION)
+
+# The definitions shown below can also be placed in an untracked RELEASE.local
+-include $(TOP)/../../RELEASE.local
+-include $(TOP)/../RELEASE.local
+-include $(TOP)/configure/RELEASE.local
+EOF
+}
+
+
 function add_RELEASE_DEV
 {
     cat > RELEASE_DEV <<EOF
@@ -620,6 +638,23 @@ EOF
 }
 
 
+
+
+function add_RELEASE_DEV_variables
+{
+    cat > RELEASE_DEV <<"EOF"
+#
+EPICS_BASE=$(EPICS_BASE)
+
+E3_REQUIRE_NAME:=$(E3_REQUIRE_NAME)
+E3_REQUIRE_VERSION:=$(E3_REQUIRE_VERSION)
+
+# The definitions shown below can also be placed in an untracked RELEASE.local
+-include $(TOP)/../../RELEASE_DEV.local
+-include $(TOP)/../RELEASE_DEV.local
+-include $(TOP)/configure/RELEASE_DEV.local
+EOF
+}
 
 
 function add_rules_module

--- a/e3TemplateGenerator/.e3_common_functions
+++ b/e3TemplateGenerator/.e3_common_functions
@@ -587,7 +587,7 @@ function add_RELEASE
 {
     cat > RELEASE <<EOF
 #
-EPICS_BASE=${_EPICS_BASE}
+EPICS_BASE:=${_EPICS_BASE}
 
 E3_REQUIRE_NAME:=${_E3_REQUIRE_NAME}
 E3_REQUIRE_VERSION:=${_E3_REQUIRE_VERSION}
@@ -606,7 +606,7 @@ function add_RELEASE_variables
 {
     cat > RELEASE <<"EOF"
 #
-EPICS_BASE=$(EPICS_BASE)
+EPICS_BASE:=$(EPICS_BASE)
 
 E3_REQUIRE_NAME:=$(E3_REQUIRE_NAME)
 E3_REQUIRE_VERSION:=$(E3_REQUIRE_VERSION)
@@ -623,7 +623,7 @@ function add_RELEASE_DEV
 {
     cat > RELEASE_DEV <<EOF
 #
-EPICS_BASE=${_EPICS_BASE}
+EPICS_BASE:=${_EPICS_BASE}
 
 E3_REQUIRE_NAME:=${_E3_REQUIRE_NAME}
 E3_REQUIRE_VERSION:=${_E3_REQUIRE_VERSION}
@@ -644,7 +644,7 @@ function add_RELEASE_DEV_variables
 {
     cat > RELEASE_DEV <<"EOF"
 #
-EPICS_BASE=$(EPICS_BASE)
+EPICS_BASE:=$(EPICS_BASE)
 
 E3_REQUIRE_NAME:=$(E3_REQUIRE_NAME)
 E3_REQUIRE_VERSION:=$(E3_REQUIRE_VERSION)
@@ -672,12 +672,12 @@ hdrs:
 
 #.PHONY: epics
 #epics:
-#	$(QUIET)echo "EPICS_BASE=$(EPICS_BASE)"        > $(TOP)/$(E3_MODULE_SRC_PATH)/configure/RELEASE
-#	$(QUIET)echo "ASYN=$(M_ASYN)"                  > $(TOP)/$(E3_MODULE_SRC_PATH)/configure/RELEASE
-#	$(QUIET)echo "SSCAN=$(M_SSCAN)"               >> $(TOP)/$(E3_MODULE_SRC_PATH)/configure/RELEASE
-#	$(QUIET)echo "SNCSEQ=$(M_SNCSEQ)"             >> $(TOP)/$(E3_MODULE_SRC_PATH)/configure/RELEASE
-#	$(QUIET)echo "CHECK_RELEASE = YES"             > $(TOP)/$(E3_MODULE_SRC_PATH)/configure/CONFIG_SITE
-#	$(QUIET)echo "INSTALL_LOCATION=$(M_DEVLIB2)"  >> $(TOP)/$(E3_MODULE_SRC_PATH)/configure/CONFIG_SITE
+#	$(QUIET)echo "EPICS_BASE:=$(EPICS_BASE)"        > $(TOP)/$(E3_MODULE_SRC_PATH)/configure/RELEASE
+#	$(QUIET)echo "ASYN:=$(M_ASYN)"                  > $(TOP)/$(E3_MODULE_SRC_PATH)/configure/RELEASE
+#	$(QUIET)echo "SSCAN:=$(M_SSCAN)"               >> $(TOP)/$(E3_MODULE_SRC_PATH)/configure/RELEASE
+#	$(QUIET)echo "SNCSEQ:=$(M_SNCSEQ)"             >> $(TOP)/$(E3_MODULE_SRC_PATH)/configure/RELEASE
+#	$(QUIET)echo "CHECK_RELEASE:=YES"             > $(TOP)/$(E3_MODULE_SRC_PATH)/configure/CONFIG_SITE
+#	$(QUIET)echo "INSTALL_LOCATION:=$(M_DEVLIB2)"  >> $(TOP)/$(E3_MODULE_SRC_PATH)/configure/CONFIG_SITE
 #	$(SUDOBASH) "$(MAKE) -C $(E3_MODULE_SRC_PATH)"
 
 EOF
@@ -776,7 +776,7 @@ function add_RELEASE_Update
     
     cat > RELEASE <<EOF
 #
-EPICS_BASE=${base_path}
+EPICS_BASE:=${base_path}
 
 E3_REQUIRE_NAME:=require
 E3_REQUIRE_VERSION:=${require_version}
@@ -790,7 +790,7 @@ EOF
 
     cat > RELEASE_DEV <<EOF
 #
-EPICS_BASE=${base_path}
+EPICS_BASE:=${base_path}
 
 E3_REQUIRE_NAME:=require
 E3_REQUIRE_VERSION:=${require_version}

--- a/e3TemplateGenerator/.e3_siteApps_functions
+++ b/e3TemplateGenerator/.e3_siteApps_functions
@@ -324,3 +324,57 @@ function add_configure_siteApps_localexample
     add_CONFIG_OPTIONS            ||  die 1 "We cannot do add_CONFIG_OPTIONS : please check it";
 }
 
+
+
+function add_configure_siteApps_variables
+{
+    # .e3_siteApps_functions
+    add_CONFIG_siteApps            ||  die 1 "We cannot do add_CONFIG_sitAppps        : please check it";
+    add_CONFIG_SITE_SYSTEMAPPS     ||  die 1 "We cannot do add_CONFIG_SITE_SYSTEMAPPS : please check it";
+    # .e3_common_functions
+    add_RELEASE_variables          ||  die 1 "We cannot do add_RELEASE         : please check it";
+    add_RELEASE_DEV_variables      ||  die 1 "We cannot do add_RELEASE_DEV     : please check it";
+    # .e3_siteApps_functions
+    add_CONFIG_MODULE_siteApps     ||  die 1 "We cannot do add_CONFIG_MODULE_siteApps     : please check it";
+    add_CONFIG_MODULE_DEV_siteApps ||  die 1 "We cannot do add_CONFIG_MODULE_DEV_siteApps : please check it";
+    add_RULES_siteApps             ||  die 1 "We cannot do add_RULES_siteApps : please check it";
+    # .e3_common_functions
+    add_CONFIG_OPTIONS             ||  die 1 "We cannot do add_CONFIG_OPTIONS : please check it";
+}
+
+
+#
+# We don't need the development mode, because all source files are located in *-loc path
+#
+function add_configure_siteApps_local_variables
+{
+    # .e3_siteApps_functions
+    add_CONFIG_siteApps_local     ||  die 1 "We cannot do add_CONFIG_sitAppps_local  : please check it";
+    add_CONFIG_SITE_SYSTEMAPPS    ||  die 1 "We cannot do add_CONFIG_SITE_SYSTEMAPPS : please check it";
+    # .e3_common_functions
+    add_RELEASE_variables         ||  die 1 "We cannot do add_RELEASE         : please check it";
+    # .e3_siteApps_functions
+    add_CONFIG_MODULE_siteApps    ||  die 1 "We cannot do add_CONFIG_MODULE_siteApps     : please check it";
+    add_RULES_siteApps_local      ||  die 1 "We cannot do add_RULES_siteApps_local : please check it";
+    # .e3_common_functions
+    add_CONFIG_OPTIONS            ||  die 1 "We cannot do add_CONFIG_OPTIONS : please check it";
+}
+
+
+#
+# We don't need the development mode, because all source files are located in *-loc path
+#
+function add_configure_siteApps_localexample_variables
+{
+    # .e3_siteApps_functions
+    add_CONFIG_siteApps_local     ||  die 1 "We cannot do add_CONFIG_sitAppps_local  : please check it";
+    add_CONFIG_SITE_SYSTEMAPPS    ||  die 1 "We cannot do add_CONFIG_SITE_SYSTEMAPPS : please check it";
+    # .e3_common_functions
+    add_RELEASE_variables         ||  die 1 "We cannot do add_RELEASE         : please check it";
+    # .e3_siteApps_functions
+    add_CONFIG_MODULE_siteApps_localexample  ||  die 1 "We cannot do add_CONFIG_MODULE_siteApps_localexample    : please check it";
+    add_RULES_siteApps_local      ||  die 1 "We cannot do add_RULES_siteApps_local : please check it";
+    # .e3_common_functions
+    add_CONFIG_OPTIONS            ||  die 1 "We cannot do add_CONFIG_OPTIONS : please check it";
+}
+

--- a/e3TemplateGenerator/.e3_siteMods_functions
+++ b/e3TemplateGenerator/.e3_siteMods_functions
@@ -204,3 +204,21 @@ function add_configure_siteMods
 
 
 
+function add_configure_siteMods_variables
+{
+    # .e3_siteMods_functions
+    add_CONFIG_siteMods            ||  die 1 "We cannot do add_CONFIG_siteMods : please check it";
+    # .e3_common_functions
+    add_RELEASE_variables          ||  die 1 "We cannot do add_RELEASE         : please check it";
+    add_RELEASE_DEV_variables      ||  die 1 "We cannot do add_RELEASE_DEV     : please check it";
+    # .e3_siteMods_functions
+    add_CONFIG_MODULE_siteMods     ||  die 1 "We cannot do add_CONFIG_MODULE_siteMods : please check it";
+    add_CONFIG_MODULE_DEV_siteMods ||  die 1 "We cannot do add_CONFIG_MODULE_DEV_siteMods : please check it";
+    add_RULES_siteMods             ||  die 1 "We cannot do add_RULES_siteMods : please check it";
+    # .e3_common_functions
+    add_CONFIG_OPTIONS             ||  die 1 "We cannot do add_CONFIG_OPTIONS : please check it";
+}
+
+
+
+

--- a/e3TemplateGenerator/e3TemplateGenerator.bash
+++ b/e3TemplateGenerator/e3TemplateGenerator.bash
@@ -202,8 +202,9 @@ function module_info
     
 }
 
-options=":m:u:d:y"
+options=":m:u:d:yr"
 SITEMODS="NO"
+RELEASEVARS="NO";
 
 while getopts "${options}" opt; do
     case "${opt}" in
@@ -220,6 +221,9 @@ while getopts "${options}" opt; do
 	    ;;
 	y)
 	    SITEMODS="YES";
+	    ;;
+	r)
+	    RELEASEVARS="YES";
 	    ;;
 	*)
 	    usage
@@ -393,17 +397,33 @@ if [ -z "${updateSource}" ]; then
 	    printf "  We cannot do further, and stop it\n";
 	    exit ;
 	else
-	    add_configure_siteMods;
+	    if [ "$RELEASEVARS" == "YES" ]; then
+		add_configure_siteMods_variables;
+	    else
+		add_configure_siteMods;
+	    fi
 	fi
     else
 	if ! [ -z "${localsrc}" ]; then
 	    if [[ "${_EPICS_MODULE_NAME}" =~ "example" ]]; then
-		add_configure_siteApps_localexample
+		if [ "$RELEASEVARS" == "YES" ]; then
+		    add_configure_siteApps_localexample_variables;
+		else
+		    add_configure_siteApps_localexample;
+		fi
 	    else
-		add_configure_siteApps_local
+		if [ "$RELEASEVARS" == "YES" ]; then
+		    add_configure_siteApps_local_variables;
+		else
+		    add_configure_siteApps_local
+		fi
 	    fi
 	else
-	    add_configure_siteApps;
+	    if [ "$RELEASEVARS" == "YES" ]; then
+		add_configure_siteApps_variables;
+	    else
+		add_configure_siteApps;
+	    fi
 	fi
     fi
     popd             # Back from configure


### PR DESCRIPTION
With the `-r` option, we can generate e3 modules with not hard-code RELEASE file, so users can use their existent environment variables in their own terminal. 